### PR TITLE
suit: build recovery image from main application

### DIFF
--- a/cmake/sysbuild/suit.cmake
+++ b/cmake/sysbuild/suit.cmake
@@ -134,6 +134,10 @@ function(suit_register_post_build_commands)
     list(APPEND dependencies "${BINARY_DIR}/zephyr/${BINARY_FILE}.bin")
   endforeach()
 
+  if (SB_CONFIG_SUIT_BUILD_RECOVERY)
+    list(APPEND dependencies recovery)
+  endif()
+
   add_custom_target(
     create_suit_artifacts
     ALL
@@ -303,6 +307,16 @@ function(suit_setup_merge)
       list(APPEND ARTIFACTS_TO_MERGE ${IMAGE_BINARY_DIR}/zephyr/uicr.hex)
     endif()
 
+    if(SB_CONFIG_SUIT_BUILD_RECOVERY)
+      get_property(
+        recovery_artifacts
+        GLOBAL PROPERTY
+        SUIT_RECOVERY_ARTIFACTS_TO_MERGE_${IMAGE_TARGET_NAME}
+      )
+
+      list(APPEND ARTIFACTS_TO_MERGE ${recovery_artifacts})
+    endif()
+
     set_property(
       GLOBAL APPEND PROPERTY SUIT_POST_BUILD_COMMANDS
       COMMAND ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/build/mergehex.py
@@ -316,6 +330,50 @@ function(suit_setup_merge)
     )
   endforeach()
 endfunction()
+
+# Build recovery image.
+#
+# Usage:
+#   suit_build_recovery()
+#
+function(suit_build_recovery)
+  include(ExternalProject)
+
+  set(sysbuild_root_path "${ZEPHYR_NRF_MODULE_DIR}/../zephyr/share/sysbuild")
+
+  ExternalProject_Add(
+    recovery
+    SOURCE_DIR ${sysbuild_root_path}
+    PREFIX ${CMAKE_BINARY_DIR}/recovery
+    INSTALL_COMMAND ""
+    CMAKE_CACHE_ARGS
+      "-DAPP_DIR:PATH=${ZEPHYR_NRF_MODULE_DIR}/samples/suit/recovery"
+      "-DBOARD:STRING=nrf54h20dk/nrf54h20/cpuapp"
+      "-DEXTRA_DTC_OVERLAY_FILE:STRING=${APP_DIR}/sysbuild/recovery.overlay"
+      "-Dhci_ipc_EXTRA_DTC_OVERLAY_FILE:STRING=${APP_DIR}/sysbuild/recovery_hci_ipc.overlay"
+      "-DSB_CONFIG_SUIT_ENVELOPE_ROOT_TEMPLATE:STRING=\\\"${ZEPHYR_NRF_MODULE_DIR}/samples/suit/recovery/app_recovery_envelope.yaml.jinja2\\\""
+      "-Dhci_ipc_CONFIG_SUIT_ENVELOPE_TEMPLATE:STRING=\\\"${ZEPHYR_NRF_MODULE_DIR}/samples/suit/recovery/rad_recovery_envelope.yaml.jinja2\\\""
+    BUILD_ALWAYS True
+)
+  ExternalProject_Get_property(recovery BINARY_DIR)
+
+  set_property(
+    GLOBAL APPEND PROPERTY SUIT_RECOVERY_ARTIFACTS_TO_MERGE_application
+    ${BINARY_DIR}/recovery/zephyr/suit_installed_envelopes_application_merged.hex)
+  set_property(
+    GLOBAL APPEND PROPERTY SUIT_RECOVERY_ARTIFACTS_TO_MERGE_application ${BINARY_DIR}/recovery/zephyr/zephyr.hex)
+
+  set_property(
+    GLOBAL APPEND PROPERTY SUIT_RECOVERY_ARTIFACTS_TO_MERGE_radio
+    ${BINARY_DIR}/recovery/zephyr/suit_installed_envelopes_radio_merged.hex)
+  set_property(
+    GLOBAL APPEND PROPERTY SUIT_RECOVERY_ARTIFACTS_TO_MERGE_radio ${BINARY_DIR}/hci_ipc/zephyr/zephyr.hex)
+
+endfunction()
+
+if(SB_CONFIG_SUIT_BUILD_RECOVERY)
+  suit_build_recovery()
+endif()
 
 if(SB_CONFIG_SUIT_ENVELOPE)
   suit_create_package()

--- a/samples/suit/smp_transfer/sample.yaml
+++ b/samples/suit/smp_transfer/sample.yaml
@@ -76,3 +76,22 @@ tests:
       - FILE_SUFFIX=extflash
       - SB_CONFIG_SUIT_ENVELOPE_SEQUENCE_NUM=2
     tags: suit
+
+  subsys.suit.smp_transfer.recovery.v1:
+    extra_args:
+      - FILE_SUFFIX=bt
+      - SB_CONFIG_SUIT_BUILD_RECOVERY=y
+    extra_configs:
+      - CONFIG_SUIT_ENVELOPE_SEQUENCE_NUM=1
+      - CONFIG_SUIT_DFU_CANDIDATE_PROCESSING_FULL=y
+    tags: suit bluetooth
+
+  subsys.suit.smp_transfer.recovery.v2:
+    extra_args:
+      - FILE_SUFFIX=bt
+      - SB_CONFIG_SUIT_BUILD_RECOVERY=y
+    extra_configs:
+      - CONFIG_SUIT_ENVELOPE_SEQUENCE_NUM=2
+      - CONFIG_SUIT_DFU_CANDIDATE_PROCESSING_FULL=y
+    tags: suit bluetooth
+

--- a/sysbuild/Kconfig.suit
+++ b/sysbuild/Kconfig.suit
@@ -69,6 +69,12 @@ config SUIT_ENVELOPE_NORDIC_TOP_DIRECTORY
 
 endif # SUIT_ENVELOPE
 
+config SUIT_BUILD_RECOVERY
+	bool "Build SUIT recovery firmware"
+	help
+	  Build the recovery firmware, which allows to recover the main application
+	  if the image on the board was damaged.
+
 config SUIT_BUILD_FLASH_COMPANION
 	bool "Build SUIT flash companion firmware"
 	help


### PR DESCRIPTION
This commit allows to build the recovery image as
a child image of a main application by using
the SB_CONFIG_SUIT_BUILD_RECOVERY option.